### PR TITLE
V2.001

### DIFF
--- a/bin/createpackage
+++ b/bin/createpackage
@@ -30,7 +30,7 @@
 ##### libui setup
 
 # script version
-Version -r 2.000 1.7
+Version -r 2.001 1.8
 
 # load mods
 LoadMod File
@@ -55,10 +55,10 @@ GetTmp -f tmpfile
 
 AddOption -n addfiles -m -k 'Add' -d 'Add files matching provided pattern to package.' a:
 AddOption -n compression -i '-j' -k 'Compression' -d 'Compression format option.' c:
-[[ 'Darwin' == "${OS}" ]] || AddOption -n encoding -i '-T' -k 'Encoding' -d 'Shar encoding format option.' e:
-AddOption -n installenv -k 'Environment' -d 'Installer command line environment.' E:
+[[ 'Darwin' == "${OS}" ]] || AddOption -n encoding -k 'Encoding' -d 'Shar encoding format option.' e:
 AddOption -n package -k 'File' -d 'The filename (or directory) for the package.' f:
 AddOption -n installer -k 'Installer' -d 'Package installer path relative to install directory.' i:
+AddOption -n prep -k 'Install Prep' -d 'Package installer preparation commands.' I:
 AddOption -n listfiles -f -k 'List Files' -d 'List files to package.' l
 AddOption -n manifest -k 'Manifest' -d 'Manifest file location.' m:
 AddOption -n pkgtype -i tarp -s tarp -s sharp -s starp -k 'Package' -d 'Package type.' p:
@@ -79,9 +79,13 @@ Files may be excluded using the -x (Exclude) option flag.
 If the provided package filename is a directory, a new file will be created in
 that directory with a name folowing: "<sourcedir>-<YYMMDD>.<pkgtype>".
 
-When extracting, if the installer is contained within the package, you can
-access it using "\${d}/<installer>", where the "\${d}" is a copy of the package
-directory and "<installer>" is the path to the installer in that directory.
+When extracting, if the installer is contained within the package, it can be
+accessed using "\${d}/<installer> \${@} \${a}", where \${d} will be replaced
+with with the temporary directory path, path/to/installer is the path to the
+installer in the extracted directory, \${@} will be replaced with any
+user-provided option flags, and \${a} will be replaced with the archive path.
+If an installer is not provided, the archive will be extracted into the current
+directory.
 EOF
 }
 
@@ -144,8 +148,8 @@ InitCallback () {
   esac
 
   Trace 'Check for existing package. (%s)' "${package}"
-  ! Force && [[ -n "${package}" && -f "${package}" ]] && \
-      Error 'Package already exists. Use -XF (Force) to overwrite.'
+  ! Overwrite && [[ -n "${package}" && -f "${package}" ]] && \
+      Error 'Package already exists. Use -XO (Overwrite) to overwrite.'
 }
 
 ##### functions
@@ -175,20 +179,24 @@ then
   Action -q 'Generate file list?' "CreatePackage -l -f files -x excludes ${sourcedir}"
 else
   Trace 'Find package type. (%s)' "${pkgtype}"
+  local i
   case "${pkgtype}" in
     sharp)
       Trace 'Files to include in shar package. (%s)' "${#files[@]}"
-      Action -s -q 'Create shar package archive?' "CreatePackage -S -n '${encoding}' -f files -x excludes -d 'Self-Extracting shar package.' -e '${installenv}' -i '${installer}' -a -s '${sourcedir}' '${package}'"
+      [[ -z "${installer}" ]] && i="-X -i 'printf \"\\n\"; sh \${@} \"\${a}\"'" || i="-i '${installer}'"
+      Action -s -q 'Create shar package archive?' "CreatePackage -S -n '${encoding}' -f files -x excludes -d 'Self-Extracting shar package.' -I '${prep}' ${i} -s '${sourcedir}' '${package}'"
       ;;
 
     starp)
       Trace 'Files to include in star package. (%s)' "${#files[@]}"
-      Action -s -q 'Create star package archive?' "CreatePackage -P -f files -x excludes -d 'Self-Extracting star package.' -e '${installenv}' -i '${installer:-star -x -f}' -a -s '${sourcedir}' '${package}'"
+      [[ -z "${installer}" ]] && i="-X -i '\${s} \${@} -x -f \"\${a}\"'" || i="-i '${installer}'"
+      Action -s -q 'Create star package archive?' "CreatePackage -P -f files -x excludes -d 'Self-Extracting star package.' -I '${prep}' ${i} -s '${sourcedir}' '${package}'"
       ;;
 
     tarp)
       Trace 'Files to include in tar package. (%s)' "${#files[@]}"
-      Action -s -q 'Create tar package archive?' "CreatePackage -T -c '${compression}' -f files -x excludes -d 'Self-Extracting tar package.' -e '${installenv}' -i '${installer}' -a -s '${sourcedir}' '${package}'"
+      [[ -z "${installer}" ]] && i="-X -i 'tar \${@} -xf \"\${a}\"'" || i="-i '${installer}'"
+      Action -s -q 'Create tar package archive?' "CreatePackage -T -c '${compression}' -f files -x excludes -d 'Self-Extracting tar package.' -I '${prep}' ${i} -s '${sourcedir}' '${package}'"
       ;;
 
     *)

--- a/bin/resetbranchbeforepullintodev
+++ b/bin/resetbranchbeforepullintodev
@@ -40,7 +40,7 @@ Version -r 2.000 1.7
 
 ##### options - libui already uses options h, H, X:
 
-AddOption -n push -t -k "Skip Push" -d "Do not \\\"git push --force\\\" the reset branch back to origin." s
+AddOption -n push -t -k "Skip Push" -d "Do not 'git push --force' the reset branch back to origin." s
 
 ##### callbacks
 

--- a/bin/showmodifieddotfiles
+++ b/bin/showmodifieddotfiles
@@ -32,7 +32,7 @@
 ##### libui setup
 
 # script version
-Version -r 2.000 1.15
+Version -r 2.001 1.16
 
 # load mods
 
@@ -52,8 +52,8 @@ AddOption -n diff -f -k 'Diff' -d 'Display file differences from reference direc
 AddOption -n usemanifest -t -k '(No) Manifest' -d 'Do not use manifest. Use all dotfiles in source directory.' M
 AddOption -n refdir -k 'Reference' -d 'The reference directory for the analysis.' r:
 AddOption -n src -i "${HOME}" -k 'Source' -d 'The source directory for the analysis.' s:
-AddOption -c "FastCallback test" -n fasttest -k '(Skip) test' -d 'Perform "fast" diff by skipping test directory.' t
-AddOption -c "FastCallback .vim" -n fastvim -k '(Skip) .vim' -d 'Perform "fast" diff by skipping .vim directory.' v
+AddOption -c "FastCallback test" -n fasttest -k '(No) test' -d 'Perform "fast" diff by skipping test directory.' T
+AddOption -c "FastCallback .vim" -n fastvim -k '(No) .vim' -d 'Perform "fast" diff by skipping .vim directory.' V
 
 ##### callbacks
 

--- a/bin/star
+++ b/bin/star
@@ -10,7 +10,7 @@
 # Manages simple archives of text only files concatenated with the separation
 # line (with no leading / trailing whitespace):
 #
-#     ===== file:<filename>:<dir permissions>:<file permissions>:file =====
+#   ===== file:<name>:<dir perms>:<file perms>:<timestamp>file <archivets>=====
 #
 #####
 #
@@ -31,7 +31,7 @@
 ##### libui setup
 
 # script version
-Version -r 2.000 2.1
+Version -r 2.001 2.2
 
 # load mods
 LoadMod Date
@@ -86,7 +86,7 @@ InitCallback () {
     fi
 
     Trace 'Check for existing archive. (%s)' "${archive}"
-    ! Force && [[ -n "${archive}" && -f "${archive}" ]] && Error 'Archive already exists. Use -XF (Force) to overwrite.'
+    ! Overwrite && [[ -n "${archive}" && -f "${archive}" ]] && Error 'Archive already exists. Use -XO (Overwrite) to overwrite.'
   fi
 
   Trace 'Check for extract. (%s)' "${extract}"

--- a/bin/wssetup
+++ b/bin/wssetup
@@ -100,12 +100,8 @@ export WORKSPACE=\"${WORKSPACE/${HOME}/\${HOME\}}\"
 return 0
 "
 
-  Trace 'Check for existing workspace file. (%s)' "${_WS_wsfile}"
-  if Overwrite || [[ ! -f "${_WS_wsfile}" ]] || Verify 'Set default workspace to "%s"? (%s)' "${WORKSPACE##*/}" "${_WS_wsfile}"
-  then
-    Trace 'Write workspace file. (%s)' "${_WS_wsfile}"
-    printf '%s' "${ws}" > "${_WS_wsfile}" || Error 'Unable to write workspace file. (%s)' "${_WS_wsfile}"
-  fi
+  Trace 'Write workspace file. (%s)' "${_WS_wsfile}"
+  printf '%s' "${ws}" > "${_WS_wsfile}" || Error 'Unable to write workspace file. (%s)' "${_WS_wsfile}"
 
   return ${?}
 }
@@ -127,17 +123,12 @@ ${@/%/${N}}
 return 0
 "
 
-  Trace 'Check for existing workspace environment file. (%s)' "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}"
-  if Overwrite || [[ ! -f "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}" ]] || \
-      Verify 'Replace "%s" environment file? (%s)' "${WORKSPACE##*/}" "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}"
-  then
-    Trace 'Create workspace environment directory. (%s)' "${_WS_wsenv}"
-    [[ -d "${_WS_wsenv}" ]] || Action "mkdir -p '${_WS_wsenv}'"
+  Trace 'Create workspace environment directory. (%s)' "${_WS_wsenv}"
+  [[ -d "${_WS_wsenv}" ]] || Action "mkdir -p '${_WS_wsenv}'"
 
-    Trace 'Write workspace environment file. (%s)' "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}"
-    printf '%s' "${wsenv}" > "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}" || \
-        Error 'Unable to write workspace environment file. (%s)' "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}"
-  fi
+  Trace 'Write workspace environment file. (%s)' "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}"
+  printf '%s' "${wsenv}" > "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}" || \
+      Error 'Unable to write workspace environment file. (%s)' "${_WS_wsenv}/${WORKSPACE##*/}${_WS_wsenvext}"
 
   return ${?}
 }

--- a/bin/wssetup
+++ b/bin/wssetup
@@ -37,7 +37,7 @@
 ##### libui setup
 
 # script version
-Version -r 2.000 1.5
+Version -r 2.001 1.6
 
 # load mods
 LoadMod File
@@ -90,7 +90,7 @@ Write_workspace () {
 #####
 #
 #	Workspace File
-#	$(date)
+#	$(date) - $(Version)
 #
 ######
 
@@ -117,13 +117,13 @@ Write_wsenv () { # <env_data>
 #####
 #
 #	Workspace Environment for ${WORKSPACE}
-#	$(date)
+#	$(date) - $(Version)
 #
 ######
 
 # configure workspace
 export WORKSPACE=\"${WORKSPACE/${HOME}/\${HOME\}}\"
-${@/%/\n}
+${@/%/${N}}
 return 0
 "
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Add starx standalone .star archive extraction tool and self-extractor support.
 * Add -I (Installer prep) and -X (No Extract) to CreatePackage command.
 * Add wssetup version number to created workspace and wsenv file headers.
+* Removed "overwrite" checks from wssetup to simplify use.
 * Add and update regression tests.
 * Update documentation.
 
@@ -18,8 +19,10 @@
 ### Incompatibilities
 
 * Change overwrite support in some tools from -XF (Force) to -XO (Overwrite).
-* Removed -a (Append Package) and -e (Install env) from CreatePackage command.
-* Removed -E (Installer environment) from createpackage.
+* Remove -a (Append Package) and -e (Install env) from CreatePackage command.
+* Remove -E (Installer environment) from createpackage.
+* Change showmodifieddotfiles -t (Skip test) option to -T (No test).
+* Change showmodifieddotfiles -v (Skip .vim) option to -V (No .vim).
 
 ## v2.000
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,26 @@
 # Change Log
 
+## v2.001
+
+### New Features / Enhancements
+
+* Add starx standalone .star archive extraction tool and self-extractor support.
+* Add -I (Installer prep) and -X (No Extract) to CreatePackage command.
+* Add wssetup version number to created workspace and wsenv file headers.
+* Add and update regression tests.
+* Update documentation.
+
+### Bug Fixes
+
+* Fix libui package content problems (lists and missing tests).
+* Remove double extraction in base createpackage archive self-extractor.
+
+### Incompatibilities
+
+* Change overwrite support in some tools from -XF (Force) to -XO (Overwrite).
+* Removed -a (Append Package) and -e (Install env) from CreatePackage command.
+* Removed -E (Installer environment) from createpackage.
+
 ## v2.000
 
 ### New Features / Enhancements

--- a/lib/sh/libui.sh
+++ b/lib/sh/libui.sh
@@ -65,7 +65,7 @@
 #
 #####
 
-[[ -n ${LIBUI_VERSION+x} ]] && return 0 || LIBUI_VERSION=2.001 # Sun Nov  5 11:22:57 EST 2023
+[[ -n ${LIBUI_VERSION+x} ]] && return 0 || LIBUI_VERSION=2.001 # Tue Nov 7 23:29:47 EST 2023
 
 #####
 #

--- a/lib/sh/libui.sh
+++ b/lib/sh/libui.sh
@@ -65,7 +65,7 @@
 #
 #####
 
-[[ -n ${LIBUI_VERSION+x} ]] && return 0 || LIBUI_VERSION=2.000 # Sat Oct 28 04:36:37 EDT 2023
+[[ -n ${LIBUI_VERSION+x} ]] && return 0 || LIBUI_VERSION=2.001 # Sun Nov  5 11:22:57 EST 2023
 
 #####
 #

--- a/lib/test/libui/test_MkDir
+++ b/lib/test/libui/test_MkDir
@@ -1,0 +1,16 @@
+#!/usr/bin/env libui
+#####
+#
+# test_MkDir
+#
+#####
+
+test_MkDir () {
+  groups=( $(groups) )
+  Action -W "MkDir -g ${groups[((AO + 1))]} -m '000' -s ${TESTDIR}/dir1/dir2"
+  LibuiPerformTest "ls -l ${TESTDIR}/dir1"
+  LibuiValidateTest -r ${?} 0 "drwxrwsrwx.* ${groups[((AO + 1))]} .* dir2"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_Overwrite_False
+++ b/lib/test/libui/test_Overwrite_False
@@ -1,0 +1,14 @@
+#!/usr/bin/env libui
+#####
+#
+# test_Overwrite_False
+#
+#####
+
+test_Overwrite_False () {
+  LibuiPerformTest 'Overwrite'
+  LibuiValidateTest ${?} 1
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_Overwrite_True
+++ b/lib/test/libui/test_Overwrite_True
@@ -1,0 +1,17 @@
+#!/usr/bin/env libui
+#####
+#
+# test_Overwrite_True
+#
+#####
+
+test_Overwrite_True () {
+  Overwrite -e
+  LibuiPerformTest 'Overwrite'
+  local tv=${?}
+  Overwrite -E
+  LibuiValidateTest "${tv}" 0
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_XC_Confirm_Action-q
+++ b/lib/test/libui/test_XC_Confirm_Action-q
@@ -1,11 +1,11 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_Confirm_Action-q
+# test_XC_Confirm_Action-q
 #
 #####
 
-test_C_Confirm_Action-q () {
+test_XC_Confirm_Action-q () {
   local t="${TERMINAL}"
   TERMINAL=true
   LibuiPerformTest 'Action -q "Confirm question?" "ls -d /tmp" <<< "yes"'

--- a/lib/test/libui/test_XC_Confirm_No_Term_Verify-C
+++ b/lib/test/libui/test_XC_Confirm_No_Term_Verify-C
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_Verify
+# test_XC_Confirm_No_Term_Verify-C
 #
 #####
 
-test_Y_Verify () {
+test_XC_Confirm_No_Term_Verify-C () {
   local t="${TERMINAL}"
-  TERMINAL=true
-  LibuiPerformTest 'Verify "Test verify?"'
+  TERMINAL=false
+  LibuiPerformTest 'Verify -C "Test verify?"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] yes'
@@ -16,6 +16,6 @@ test_Y_Verify () {
 }
 
 # test setup
-_Test_opt+='-X Y '
+_Test_opt+='-X C '
 
 return 0

--- a/lib/test/libui/test_XC_Confirm_Verify
+++ b/lib/test/libui/test_XC_Confirm_Verify
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_Verify-C
+# test_XC_Confirm_Verify
 #
 #####
 
-test_C_Verify-C () {
+test_XC_Confirm_Verify () {
   local t="${TERMINAL}"
   TERMINAL=true
-  LibuiPerformTest 'Verify -C "Test verify?" <<< "yes"'
+  LibuiPerformTest 'Verify "Test verify?" <<< "yes"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] '

--- a/lib/test/libui/test_XC_Confirm_Verify-C
+++ b/lib/test/libui/test_XC_Confirm_Verify-C
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_Confirm_Verify
+# test_XC_Confirm_Verify-C
 #
 #####
 
-test_C_Confirm_Verify () {
+test_XC_Confirm_Verify-C () {
   local t="${TERMINAL}"
   TERMINAL=true
-  LibuiPerformTest 'Verify "Test verify?" <<< "yes"'
+  LibuiPerformTest 'Verify -C "Test verify?" <<< "yes"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] '

--- a/lib/test/libui/test_XC_No_Term_Ask_Confirm_True
+++ b/lib/test/libui/test_XC_No_Term_Ask_Confirm_True
@@ -1,11 +1,11 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_No_Term_Ask_Confirm_True
+# test_XC_No_Term_Ask_Confirm_True
 #
 #####
 
-test_C_No_Term_Ask_Confirm_True () {
+test_XC_No_Term_Ask_Confirm_True () {
   local t="${TERMINAL}"
   TERMINAL=false
   Yes -e

--- a/lib/test/libui/test_XC_No_Term_Verify-C
+++ b/lib/test/libui/test_XC_No_Term_Verify-C
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_Yes_Verify
+# test_XC_No_Term_Verify-C
 #
 #####
 
-test_Y_Yes_Verify () {
+test_XC_No_Term_Verify-C () {
   local t="${TERMINAL}"
-  TERMINAL=true
-  LibuiPerformTest 'Verify "Test verify?"'
+  TERMINAL=false
+  LibuiPerformTest 'Verify -C "Test verify?"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] yes'
@@ -16,6 +16,6 @@ test_Y_Yes_Verify () {
 }
 
 # test setup
-_Test_opt+='-X Y '
+_Test_opt+='-X C '
 
 return 0

--- a/lib/test/libui/test_XC_Verify-C
+++ b/lib/test/libui/test_XC_Verify-C
@@ -1,11 +1,11 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_Confirm_Verify-C
+# test_XC_Verify-C
 #
 #####
 
-test_C_Confirm_Verify-C () {
+test_XC_Verify-C () {
   local t="${TERMINAL}"
   TERMINAL=true
   LibuiPerformTest 'Verify -C "Test verify?" <<< "yes"'

--- a/lib/test/libui/test_XO_Overwrite
+++ b/lib/test/libui/test_XO_Overwrite
@@ -1,19 +1,19 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_Yes
+# test_XO_Overwrite
 #
 #####
 
-test_Y_Yes () {
-  LibuiPerformTest 'Yes'
+test_XO_Overwrite () {
+  LibuiPerformTest 'Overwrite'
   local tv=${?}
-  Yes -E
+  Overwrite -E
   LibuiValidateTest "${tv}" 0
   return ${?}
 }
 
 # test setup
-_Test_opt+='-X Y '
+_Test_opt+='-X O '
 
 return 0

--- a/lib/test/libui/test_XO_Overwrite-E
+++ b/lib/test/libui/test_XO_Overwrite-E
@@ -1,19 +1,19 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_Yes-E
+# test_XO_Overwrite-E
 #
 #####
 
-test_Y_Yes-E () {
-  Yes -E
-  LibuiPerformTest 'Yes'
+test_XO_Overwrite-E () {
+  Overwrite -E
+  LibuiPerformTest 'Overwrite'
   local tv=${?}
   LibuiValidateTest "${tv}" 1
   return ${?}
 }
 
 # test setup
-_Test_opt+='-X Y '
+_Test_opt+='-X O '
 
 return 0

--- a/lib/test/libui/test_XY_No_Term_Verify
+++ b/lib/test/libui/test_XY_No_Term_Verify
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_No_Term_Verify-C
+# test_XY_No_Term_Verify
 #
 #####
 
-test_C_No_Term_Verify-C () {
+test_XY_No_Term_Verify () {
   local t="${TERMINAL}"
   TERMINAL=false
-  LibuiPerformTest 'Verify -C "Test verify?"'
+  LibuiPerformTest 'Verify "Test verify?"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] yes'
@@ -16,6 +16,6 @@ test_C_No_Term_Verify-C () {
 }
 
 # test setup
-_Test_opt+='-X C '
+_Test_opt+='-X Y '
 
 return 0

--- a/lib/test/libui/test_XY_Verify
+++ b/lib/test/libui/test_XY_Verify
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_C_Confirm_No_Term_Verify-C
+# test_XY_Verify
 #
 #####
 
-test_C_Confirm_No_Term_Verify-C () {
+test_XY_Verify () {
   local t="${TERMINAL}"
-  TERMINAL=false
-  LibuiPerformTest 'Verify -C "Test verify?"'
+  TERMINAL=true
+  LibuiPerformTest 'Verify "Test verify?"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] yes'
@@ -16,6 +16,6 @@ test_C_Confirm_No_Term_Verify-C () {
 }
 
 # test setup
-_Test_opt+='-X C '
+_Test_opt+='-X Y '
 
 return 0

--- a/lib/test/libui/test_XY_XC_Yes_No_Term_Verify-C
+++ b/lib/test/libui/test_XY_XC_Yes_No_Term_Verify-C
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_No_Term_Verify
+# test_XY_XC_Yes_No_Term_Verify-C
 #
 #####
 
-test_Y_No_Term_Verify () {
+test_XY_XC_Yes_No_Term_Verify-C () {
   local t="${TERMINAL}"
   TERMINAL=false
-  LibuiPerformTest 'Verify "Test verify?"'
+  LibuiPerformTest 'Verify -C "Test verify?"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] yes'
@@ -16,6 +16,6 @@ test_Y_No_Term_Verify () {
 }
 
 # test setup
-_Test_opt+='-X Y '
+_Test_opt+='-X Y -X C '
 
 return 0

--- a/lib/test/libui/test_XY_Yes
+++ b/lib/test/libui/test_XY_Yes
@@ -1,17 +1,19 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Yes-e
+# test_XY_Yes
 #
 #####
 
-test_Yes-e () {
-  Yes -e
+test_XY_Yes () {
   LibuiPerformTest 'Yes'
   local tv=${?}
   Yes -E
   LibuiValidateTest "${tv}" 0
   return ${?}
 }
+
+# test setup
+_Test_opt+='-X Y '
 
 return 0

--- a/lib/test/libui/test_XY_Yes-E
+++ b/lib/test/libui/test_XY_Yes-E
@@ -1,0 +1,19 @@
+#!/usr/bin/env libui
+#####
+#
+# test_XY_Yes-E
+#
+#####
+
+test_XY_Yes-E () {
+  Yes -E
+  LibuiPerformTest 'Yes'
+  local tv=${?}
+  LibuiValidateTest "${tv}" 1
+  return ${?}
+}
+
+# test setup
+_Test_opt+='-X Y '
+
+return 0

--- a/lib/test/libui/test_XY_Yes_Action-Cq
+++ b/lib/test/libui/test_XY_Yes_Action-Cq
@@ -1,11 +1,11 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_Yes_Action-Cq
+# test_XY_Yes_Action-Cq
 #
 #####
 
-test_Y_Yes_Action-Cq () {
+test_XY_Yes_Action-Cq () {
   local t="${TERMINAL}"
   TERMINAL=true
   LibuiPerformTest 'Action -C -q "Yes question?" "ls -d /tmp"'

--- a/lib/test/libui/test_XY_Yes_No_Term_Action-Cq
+++ b/lib/test/libui/test_XY_Yes_No_Term_Action-Cq
@@ -1,11 +1,11 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_Yes_No_Term_Action-Cq
+# test_XY_Yes_No_Term_Action-Cq
 #
 #####
 
-test_Y_Yes_No_Term_Action-Cq () {
+test_XY_Yes_No_Term_Action-Cq () {
   local t="${TERMINAL}"
   TERMINAL=false
   LibuiPerformTest 'Action -C -q "Yes question?" "ls -d /tmp"'

--- a/lib/test/libui/test_XY_Yes_Verify
+++ b/lib/test/libui/test_XY_Yes_Verify
@@ -1,14 +1,14 @@
 #!/usr/bin/env libui
 #####
 #
-# test_Y_C_Yes_No_Term_Verify-C
+# test_XY_Yes_Verify
 #
 #####
 
-test_Y_C_Yes_No_Term_Verify-C () {
+test_XY_Yes_Verify () {
   local t="${TERMINAL}"
-  TERMINAL=false
-  LibuiPerformTest 'Verify -C "Test verify?"'
+  TERMINAL=true
+  LibuiPerformTest 'Verify "Test verify?"'
   local tv=${?}
   TERMINAL="${t}"
   LibuiValidateTest "${tv}" 0 'Test verify? (y/n) [yes] yes'
@@ -16,6 +16,6 @@ test_Y_C_Yes_No_Term_Verify-C () {
 }
 
 # test setup
-_Test_opt+='-X Y -X C '
+_Test_opt+='-X Y '
 
 return 0

--- a/share/doc/libui-dictionary.md
+++ b/share/doc/libui-dictionary.md
@@ -290,13 +290,12 @@ environment specification is a variable name that contains an environment string
 prepended when executing the provided installer command. It is expected that the
 installer is a libui script.
 
-* **-a** - append archive file as parameter at end of installer command string
 * **-c** - tar compression option flag to use
 * **-d** - description to use in package header
-* **-e** - environment string to prepend to installer command string
 * **-f** - array variable name containing file list to include in package
 * **-h** - function to call to generate the package header
 * **-i** - installer command (included in self-extracting package header)
+* **-I** - installer preparation commands (to set up environment, etc.)
 * **-l** - generate package contents list instead of creating package
 * **-n** - encoding to use (man 1 shar for details)
 * **-N** - do not create a package, only create a tar archive
@@ -305,9 +304,10 @@ installer is a libui script.
 * **-S** - create a shar package (.sharp)
 * **-T** - create a tar package (.tarp)
 * **-x** - array variable name containing file list to exclude from package
+* **-X** - do not extract the archive before running the installer
 
 ```
-CreatePackage [-a|-l|-N|-P|-S|-T] [-c <compression>] [-d <description>] [-e <environment_spec>] [-f <filelist_array_variable_name>] [-h <header_command>] [-i <installer>] [-n <encoding>] [-s <source_directory>] [-x <exclude_array_variable_name>] <package_filename>
+CreatePackage [-l|-N|-P|-S|-T|-X] [-c <compression>] [-d <description>] [-f <filelist_array_variable_name>] [-h <header_command>] [-i <installer>] [-I <installer_prep>] [-n <encoding>] [-s <source_directory>] [-x <exclude_array_variable_name>] <package_filename>
 ```
 
 ### Drop (man libui.sh) - Utility function to drop a value from an array.

--- a/share/man/man1/createpackage.1
+++ b/share/man/man1/createpackage.1
@@ -13,7 +13,7 @@
 .\" whether in an action of contract, tort, or otherwise, arising from, out of,
 .\" or in connection with this content or use of the associated files.
 .\"
-.Dd October 21, 2023
+.Dd November 5, 2023
 .Dt CREATEPACKAGE 1
 .Os
 .Sh NAME

--- a/share/man/man1/resetbranchbeforepullintodev.1
+++ b/share/man/man1/resetbranchbeforepullintodev.1
@@ -13,7 +13,7 @@
 .\" whether in an action of contract, tort, or otherwise, arising from, out of,
 .\" or in connection with this content or use of the associated files.
 .\"
-.Dd October 21, 2023
+.Dd November 1, 2023
 .Dt RESETBRANCHBEFOREPULLINTODEV 1
 .Os
 .Sh NAME

--- a/share/man/man1/star.1
+++ b/share/man/man1/star.1
@@ -13,12 +13,12 @@
 .\" whether in an action of contract, tort, or otherwise, arising from, out of,
 .\" or in connection with this content or use of the associated files.
 .\"
-.Dd October 21, 2023
+.Dd November 5, 2023
 .Dt STAR 1
 .Os
 .Sh NAME
 .Nm star
-.Nd Manage simple archives of text only files
+.Nd Manage simple text archives (.star files)
 .Sh SYNOPSIS
 .Sy star
 .Op Fl c Fl x Fl h Fl H
@@ -26,9 +26,9 @@
 .Op Fl X Ar <option>
 .Op Ar <filepath>
 .Sh DESCRIPTION
-Manages simple text only file archives where the files are concatenated
-together with a separator line containing the filename and directory and file
-permissions.
+Manages simple text archives (.star files) where only text files are
+concatenated together with a separator line containing the filename, directory,
+file permissions and file timestamp.
 .Pp
 The
 .Nm
@@ -46,7 +46,7 @@ Available command line options are:
 .It Fl c
 Create
 .Pp
-Create a new archive from the provided
+Create a new text archive (.star file) from the provided
 .Ar <filepath> .
 .Pp
 Note: If any files in the provided
@@ -110,11 +110,15 @@ or
 The script will create or read from the file provided with the
 .Fl f Ar <filename>
 option flag.
-The script will collect, with the
+The script, with the
 .Fl c
-(Crate) option flag, or create, with the
+(Crate) option flag, will collect files from
+.Ar <filepath>
+parameter.
+With the
 .Fl x
-(Extract) option flag, files from the directory provided with the
+(Extract) option flag, the script will create files in the directory provided as
+the
 .Ar <filepath>
 parameter.
 .Sh EXAMPLES
@@ -125,8 +129,14 @@ Some example uses include:
 .Pp
 Creates an archive named "keep.star" in the /tmp directory with the text files
 contained in the current directory.
+.Bd -literal -offset 4n
+.Sy star -x -f /tmp/archive.star .
+.Ed
+.Pp
+Extracts the files contained in archive.star into the current directory.
 .Sh SEE ALSO
 .Xr createpackage 1 ,
+.Xr starx 1 ,
 .Xr libui.sh 3
 .Sh AUTHORS
 .An F Harvell

--- a/share/man/man1/starx.1
+++ b/share/man/man1/starx.1
@@ -1,0 +1,77 @@
+.\" Manpage for starx {libui tool}
+.\" Please contact fharvell@siteservices.net to correct errors or typos.
+.\"
+.\" Copyright 2018-2023 siteservices.net, Inc. and made available in the public
+.\" domain.  Permission is unconditionally granted to anyone with an interest,
+.\" the rights to use, modify, publish, distribute, sublicense, and/or sell this
+.\" content and associated files.
+.\"
+.\" All content is provided "as is", without warranty of any kind, expressed or
+.\" implied, including but not limited to merchantability, fitness for a
+.\" particular purpose, and noninfringement.  In no event shall the authors or
+.\" copyright holders be liable for any claim, damages, or other liability,
+.\" whether in an action of contract, tort, or otherwise, arising from, out of,
+.\" or in connection with this content or use of the associated files.
+.\"
+.Dd November 5, 2023
+.Dt STARX 1
+.Os
+.Sh NAME
+.Nm starx
+.Nd Extract simple text archives (.star files)
+.Sh SYNOPSIS
+.Sy starx
+.Op Ar <filepath>
+.Sh DESCRIPTION
+Extracts files from a simple text archive (.star file) into the current
+directory.
+The
+.Sy starx
+command was implemented as a standalone, extract-only command.
+The
+.Xr star 1
+command provides full support for simple text archives (.star files).
+See the
+.Xr star 1
+command for more information.
+.Pp
+The
+.Nm
+script can be executed using the following:
+.Bd -ragged -offset 4n
+.Sy starx
+.Op Ar <filepath>
+.Ed
+.Pp
+When executed, the script extracts files from the
+.Ar <filepath>
+archive into the current directory.
+.Sh FILES
+The script will read from the file path provided as
+.Ar <filepath> .
+.Sh EXAMPLES
+This example:
+.Bd -literal -offset 4n
+.Sy starx /tmp/archive.star
+.Ed
+.Pp
+Extracts the files contained in archive.star into the current directory.
+.Sh NOTES
+While the
+.Sy starx
+command is provided with the
+.Xr libuil.sh 3
+user interface library, it does not utilize the
+.Xr libui.sh 3
+library. It is provided as a separate shell script to support the transfer of
+simple text archive (.star) files when the full
+.Xr libui.sh 3
+library has not yet been installed.
+.Sh SEE ALSO
+.Xr star 1 ,
+.Xr libui.sh 3
+.Sh AUTHORS
+.An F Harvell
+.Mt <fharvell@siteservices.net>
+.Sh BUGS
+No known bugs.

--- a/share/man/man1/wssetup.1
+++ b/share/man/man1/wssetup.1
@@ -13,7 +13,7 @@
 .\" whether in an action of contract, tort, or otherwise, arising from, out of,
 .\" or in connection with this content or use of the associated files.
 .\"
-.Dd October 31, 2023
+.Dd November 3, 2023
 .Dt WSSETUP 1
 .Os
 .Sh NAME

--- a/share/man/man3/libui.sh.3
+++ b/share/man/man3/libui.sh.3
@@ -14,7 +14,7 @@
 .\" whether in an action of contract, tort, or otherwise, arising from, out of,
 .\" or in connection with this content or use of the associated files.
 .\"
-.Dd October 30, 2023
+.Dd November 3, 2023
 .Dt LIBUI.SH 3
 .Os
 .Sh NAME

--- a/share/man/man3/libuiPackage.sh.3
+++ b/share/man/man3/libuiPackage.sh.3
@@ -14,7 +14,7 @@
 .\" whether in an action of contract, tort, or otherwise, arising from, out of,
 .\" or in connection with this content or use of the associated files.
 .\"
-.Dd October 21, 2023
+.Dd November 5, 2023
 .Dt LIBUIPACKAGE.SH 3
 .Os
 .Sh NAME
@@ -25,9 +25,9 @@ user interface library
 .Sh SYNOPSIS
 .Sy LoadMod Package
 .Pp
-.Sy CreatePackage Oo Fl a Fl l Fl N Fl P Fl S Fl T Oc Oo Fl c Ar <compression> Oc Oo Fl d Ar <description> Oc Oo Fl e Ar <environment_spec> Oc Oo Fl f Ar <filelist_array_var_name> Oc Oo Fl h Ar <header_command> Oc Oo Fl i Ar <installer> Oc Oo Fl n Ar <encoding> Oc Oo Fl s Ar <source_directory> Oc Oo Fl x Ar <exclude_array_var_name> Oc Ar <package_filename>
+.Sy CreatePackage Oo Fl l Fl N Fl P Fl S Fl T Fl X Oc Oo Fl c Ar <compression> Oc Oo Fl d Ar <description> Oc Oo Fl f Ar <filelist_array_var_name> Oc Oo Fl h Ar <header_command> Oc Oo Fl i Ar <installer> Oc Oo Fl I Ar <installer_prep> Oc Oo Fl n Ar <encoding> Oc Oo Fl s Ar <source_directory> Oc Oo Fl x Ar <exclude_array_var_name> Oc Ar <package_filename>
 .Pp
-.Sy _CreatePackageHeader Oo Fl a Fl P Fl S Fl T Oc Oo Fl d Ar <description> Oc Oo Fl e Ar <environment_spec> Oc Oo Fl i Ar <installer> Oc Oo Fl s Ar <source_directory> Oc Ar <package_filename>
+.Sy _CreatePackageHeader Oo Fl P Fl S Fl T Fl X Oc Oo Fl d Ar <description> Oc Oo Fl i Ar <installer> Oc Oo Fl I Ar <installer_prep> Oc Oo Fl s Ar <source_directory> Oc Ar <package_filename>
 .Pp
 .Sy ListPackage Ar <package>
 .Sh DESCRIPTION
@@ -36,11 +36,13 @@ The
 .Xr libui.sh 3
 mod provides functions for creating and listing the contents of self-extracting
 packages.
-The self-extracting packages can be tar or shar based.
+The self-extracting packages can be tar, shar, or star based.
 .Pp
 Note: The use of the tar format package is recommended.
-The shar format is provided in case the package content must be reviewed by a
-human (e.g. in a classified environment).
+The shar format is provided in case the package content must be sent over a
+non-binary transport, or requires high portability.
+The star format is provided in case the package content must be reviewed by a
+human (e.g., transfer in or out of a classified environment).
 .Pp
 The
 .Nm
@@ -52,7 +54,7 @@ specified
 .Ar <source_directory>
 directory.
 .Pp
-.Sy CreatePackage Oo Fl a Fl l Fl N Fl P Fl S Fl T Oc Oo Fl c Ar <compression> Oc Oo Fl d Ar <description> Oc Oo Fl e Ar <environment_spec> Oc Oo Fl f Ar <filelist_array_var_name> Oc Oo Fl h Ar <header_command> Oc Oo Fl i Ar <installer> Oc Oo Fl n Ar <encoding> Oc Oo Fl s Ar <source_directory> Oc Oo Fl x Ar <exclude_array_var_name> Oc Ar <package_filename>
+.Sy CreatePackage Oo Fl l Fl N Fl P Fl S Fl T Fl X Oc Oo Fl c Ar <compression> Oc Oo Fl d Ar <description> Oc Oo Fl f Ar <filelist_array_var_name> Oc Oo Fl h Ar <header_command> Oc Oo Fl i Ar <installer> Oc Oo Fl I Ar <installer_prep> Oc Oo Fl n Ar <encoding> Oc Oo Fl s Ar <source_directory> Oc Oo Fl x Ar <exclude_array_var_name> Oc Ar <package_filename>
 .Pp
 When executed, the
 .Sy CreatePackage
@@ -63,14 +65,6 @@ directory.
 .Pp
 The available options are:
 .Bl -tag -offset 4n -width 4n
-.It Fl a
-Append Archive
-.Pp
-This option is passed through to the
-.Ar <header_command> .
-See the
-.Sx _CreatePackageHeader
-command for more information.
 .It Fl c
 Compression
 .Pp
@@ -88,19 +82,6 @@ See
 for more information.
 .It Fl d Ar <description>
 Description
-.It Fl e Ar <environment_spec>
-This option is passed through to the
-.Ar <header_command> .
-See the
-.Sx _CreatePackageHeader
-command for more information.
-Environment
-.Pp
-The
-.Ar <environment_spec>
-will be added before the command line that executes the installer.
-This is typically used to pass an environment variable into the installer
-process.
 .It Fl f Ar <filelist_array_var_name>
 Include
 .Pp
@@ -128,33 +109,12 @@ In other words, the
 .Ar <header_command>
 will be called as:
 .Bd -literal -offset 4n
-.Sy <header_command> Oo Fl a Fl S Fl T Oc Oo Fl e Ar <environment_spec> Oc Oo Fl i Ar <installer> Oc Oo Fl s Ar <source_directory> Oc Ar <package_filename>
+.Sy <header_command> Oo Fl P Fl S Fl T Fl X Oc Oo Fl d Ar <description> Oc Oo Fl i Ar <installer> Oc Oo Fl I Ar <installer_prep> Oc Oo Fl s Ar <source_directory> Oc Ar <package_filename>
 .Ed
 .Pp
-Where
-.Fl a
-will be used to append the archive file as the last parameter on the
-.Ar <installer>
-command line when the self-extracting header is executed,
-.Fl e Ar <environment_spec>
-will add
-.Ar <environment_spec>
-before the command line that executes the installer,
-.Fl i Ar <installer>
-is the installer command to execute,
-.Fl s Ar <source_directory>
-is the package source directory,
-and
-.Ar <package_filename>
-is the name of the package file being generated.
-.It Fl i Ar <installer>
-Installer
-.Pp
-This option is passed through to the
-.Ar <header_command> .
 See the
 .Sx _CreatePackageHeader
-command for more information.
+command for information associated with each option flag and parameter.
 .It Fl l
 List
 .Pp
@@ -219,16 +179,17 @@ This option is also passed through to the
 See the
 .Sx _CreatePackageHeader
 command for more information.
-This is the default format if neither
-.Fl S
-(Sharp) or
-.Fl T
-(Tarp) option is provided.
+This is the default format.
 .It Fl x Ar <exclude_array_var_name>
 (E)xclude
 .Pp
 The name of an array varaiable that contains a list of directories and files in
 the
+.It Fl X
+No Extraction
+.Pp
+Do not extract the archive into the temporary directory before executing the
+installer.
 .It Ar <package_filename>
 Package Filename
 .Pp
@@ -266,7 +227,7 @@ names.
 .Ss _CreatePackageHeader
 The _CreatePackageHeader command.
 .Pp
-.Sy _CreatePackageHeader Oo Fl a Fl P Fl S Fl T Oc Oo Fl d Ar <description> Oc Oo Fl e Ar <environment_spec> Oc Oo Fl i Ar <installer> Oc Oo Fl s Ar <source_directory> Oc Ar <package_filename>
+.Sy _CreatePackageHeader Oo Fl P Fl S Fl T Fl X Oc Oo Fl d Ar <description> Oc Oo Fl i Ar <installer> Oc Oo Fl I Ar <installer_prep> Oc Oo Fl s Ar <source_directory> Oc Ar <package_filename>
 .Pp
 When executed, the
 .Sy _CreatePackageHeader
@@ -310,16 +271,6 @@ their final destination.
 .Pp
 The available options are:
 .Bl -tag -offset 4n -width 4n
-.It Fl a
-Append Archive
-.Pp
-When included, the
-.Fl a
-(Append Archive) option will add the archive filename as the last element on the
-installer command line.
-See the
-.Fl i
-(installer) option for more information.
 .It Fl d Ar <description>
 Description
 .Pp
@@ -329,14 +280,6 @@ will be added as the first text line in the package header.
 If not provided, it will default to "Self-Extracting
 .Ar <source_directory>
 Package".
-.It Fl e Ar <environment_spec>
-Environment
-.Pp
-The
-.Ar <environment_spec>
-will be added before the command line that executes the installer.
-This is typically used to pass an environment variable into the installer
-process.
 .It Fl i Ar <installer>
 Installer
 .Pp
@@ -344,12 +287,33 @@ The path of the installer program, relative to the
 .Ar <source_directory>
 directory.
 When the self-extracting archive package is executed, it will extract the
-installation program directory and then execute the installer.
+archive into a temporary directory and then execute the installer from that
+temporary directory.
+The format of the
+.Ar <installer>
+should be similar to:
+.Bd -literal -offset 4n
+.Sy \e${d}/path/to/installer \e${@} "\e${a}"
+.Ed
 .Pp
-Note: The contents of the parent directory containing the installation program
-will be available in the temporary installation directory and relative to the
-.Ar <source_directory>
-root.
+Where
+.Sy \e${d}
+will be replaced with with the temporary directory path,
+.Sy path/to/installer
+is the path to the installer in the extracted directory,
+.Sy \e${@}
+will be replaced with any user-provided option flags, and
+.Sy \e${a}
+will be replaced with the archive path.
+The default installer is:
+.Bd -literal -offset 4n
+.Sy \e${d}/.installer \e${@} "\e${a}"
+.Ed
+.It Fl I Ar <installer_prep>
+Installer Prep
+.Pp
+Shell commands to be executed in the self-extractor prior to running the
+installer.
 .It Fl P
 Simple Text Archive Package
 .Pp
@@ -367,11 +331,12 @@ A shar archive package (.sharp) will be created.
 Tarp
 .Pp
 A tar archive package (.tarp) will be created.
-This is the default format if neither
-.Fl S
-(Sharp) or
-.Fl T
-(Tarp) option is provided.
+This is the default format.
+.It X
+No Extraction
+.Pp
+Do not extract the archive into the temporary directory before executing the
+installer.
 .It Ar <package_filename>
 Package Filename
 .Pp
@@ -422,7 +387,7 @@ When executed, the self-extracting header will create a temporary directory,
 extract the lib/sh directory, and execute
 the installer from the root of the extracted package.
 .Bd -literal -offset 4n
-.Sy _CreatePackageHeader Fl T Fl a Fl i Ar ./path/to/installer Ar package.tarp
+.Sy _CreatePackageHeader Fl T Fl i Ar '\e${d}/path/to/installer\ \e${@}\ \e${a}' Ar package.tarp
 .Ed
 .Pp
 Creates a


### PR DESCRIPTION
## v2.001

### New Features / Enhancements

* Add starx standalone .star archive extraction tool and self-extractor support.
* Add -I (Installer prep) and -X (No Extract) to CreatePackage command.
* Add wssetup version number to created workspace and wsenv file headers.
* Removed "overwrite" checks from wssetup to simplify use.
* Add and update regression tests.
* Update documentation.

### Bug Fixes

* Fix libui package content problems (lists and missing tests).
* Remove double extraction in base createpackage archive self-extractor.

### Incompatibilities

* Change overwrite support in some tools from -XF (Force) to -XO (Overwrite).
* Remove -a (Append Package) and -e (Install env) from CreatePackage command.
* Remove -E (Installer environment) from createpackage.
* Change showmodifieddotfiles -t (Skip test) option to -T (No test).
* Change showmodifieddotfiles -v (Skip .vim) option to -V (No .vim).