### PR TITLE
V2.011

### DIFF
--- a/bin/mless
+++ b/bin/mless
@@ -28,7 +28,7 @@
 ##### libui setup
 
 # script version
-Version -r 2.000 1.7
+Version -r 2.011 1.8
 
 # load mods
 LoadMod File
@@ -143,7 +143,7 @@ do
         s/^>>\s/  |  |  /;
         s/^>\s/  |  /;
       }" | \
-      sed -E '/^\s*$/{N; /^\s*\n\s*$/s///}' | \
+      sed '/^$/N;/^\n$/D' | \
       sed -E "/^\`\`\`$/,/^\`\`\`$/{/\`\`\`/d; s/^/    ${code}/; s/$/${D}/;}" | \
       sed -E 's/\\\\/\\/g' | \
       sed -E 's/\\([^\\])/\1/g' | \

--- a/bin/star
+++ b/bin/star
@@ -31,7 +31,7 @@
 ##### libui setup
 
 # script version
-Version -r 2.010 2.7
+Version -r 2.011 2.8
 
 # load mods
 LoadMod Convert
@@ -45,7 +45,7 @@ ts=$(date +%s)
 groupmode='g+wX'
 long=false
 retval=0
-sign="$(command -v sha1sum 2> /dev/null)"; sign=${sign:-$(command -v shasum 2> /dev/null)}
+sign="$(command -v sha1sum 2> /dev/null)"; sign="${sign:-$(command -v shasum 2> /dev/null)}"
 GetTmp tmpdir
 
 ##### options - libui already uses options h, H, X:

--- a/bin/starx
+++ b/bin/starx
@@ -32,9 +32,9 @@
 # defaults
 ts=$(date +%s)
 rv=0
-TMPDIR=${TMPDIR:-/tmp}
+TMPDIR="${TMPDIR:-/tmp}"
 tmpdir="$(mktemp -d "${TMPDIR%/}/${0##*/}.XXXXXX")"
-sign="$(command -v sha1sum 2> /dev/null)"; sign=${sign:-$(command -v shasum 2> /dev/null)}
+sign="$(command -v sha1sum 2> /dev/null)"; sign="${sign:-$(command -v shasum 2> /dev/null)}"
 archive="${1}"
 
 # error handler

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### New Features / Enhancements
 
 * Add new `${ARCH}` variable that provides the system architecture.
-* Add new `${BSDPATH}` variable that provides path for BSD command versions.
+* Add new `${BSDPATH}` variable that provides the path for BSD command versions.
 * Add new `${OS_DIST}` variable that provides the OS distribution.
 * Ignore `.DS_Store` files when comparing directories with `libui -[uvV]`.
 * Improve `mless` multi-line handling.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,31 @@
 # Change Log
 
+## v2.011
+
+### New Features / Enhancements
+
+* Add new `${ARCH}` variable that provides the system architecture.
+* Add new `${BSDPATH}` variable that provides path for BSD command versions.
+* Add new `${OS_DIST}` variable that provides the OS distribution.
+* Ignore `.DS_Store` files when comparing directories with `libui -[uvV]`.
+* Improve `mless` multi-line handling.
+* Multiple tweaks for better support in bash on Solaris 10 (zsh not supported).
+* Add "gtarp" package type in libui Package mod for gtar installation (Solaris).
+* Add and update regression tests.
+* Update documentation.
+
+### Bug Fixes
+
+* Fix libui File mod `GetFileList` bug on filenames with leading period in bash.
+* Use ls -i instead of stat for inodes in libui File mod `PathMatches` (Solaris).
+* Tweak libui Package mod package header use of head -n / tail -n (Solaris).
+* Round fractional `sleep` values up one second if the fractional sleep fails.
+* Add quotes in a few variable assignments to reduce security exposure.
+
+### Incompatibilities
+
+* The `${OS}` on Solaris is now "SunOS" (and `${OS_DIST}` is "Solaris").
+
 ## v2.010
 
 ### New Features / Enhancements

--- a/lib/sh/libuiInfo.sh
+++ b/lib/sh/libuiInfo.sh
@@ -113,8 +113,7 @@ UsageInfo () {
     for _UsageInfo_p in "${_ou[@]}"
     do
       _UsageInfo_d="$(printf "  -%s  %-${_UsageInfo_x}s - %s" "${_UsageInfo_p}" "${_ok[${_UsageInfo_i}]}" "${_od[${_UsageInfo_i}]}")"
-      eval "_UsageInfo_d=\"${_UsageInfo_d//\"/\\\"}\""
-      printf '%s\n' "${_UsageInfo_d}"
+      eval "printf '%s\n' \"${_UsageInfo_d}\""
       ((_UsageInfo_i++))
     done
 

--- a/lib/sh/libuiLibui.sh
+++ b/lib/sh/libuiLibui.sh
@@ -32,7 +32,7 @@
 #
 #####
 
-Version -r 2.010 -m 1.18
+Version -r 2.011 -m 1.19
 
 ##### configuration
 
@@ -288,6 +288,8 @@ regression testing, capabilities demonstration, and usage statistics reports.
 
 Hints: ${D0}Use the "-n" (New Script) option to generate a new liubi script.${D}
        Use the "-d" (Demo) option to see the display formats available.
+
+Shell environment: ${SHENV}
 
 Current test mode options:
     AddOption F/T test. (b: ${_Util_addoptft})
@@ -852,7 +854,7 @@ LibuiUnity () { # [-d|-u|-U|-v]
   StartSpinner 'Comparing "%s" with commonroot "%s".' "${_Util_libuiroot}" "${COMMONROOT}"
 
   ${_M} && _Trace 'Verify %s environment with %s.' "${COMMONROOT}" "${_Util_libuiroot}"
-  for _Util_file in $(find . -name '*.sw*' -prune -o -type f -print)
+  for _Util_file in $(find . -name '*.sw*' -o -name '.DS_Store*' -prune -o -type f -print)
   do
     _Util_file="${_Util_file#./}"
     if [[ -f "${COMMONROOT}/${_Util_file}" ]]

--- a/lib/sh/libuiSpinner.sh
+++ b/lib/sh/libuiSpinner.sh
@@ -27,7 +27,7 @@
 #
 #####
 
-Version -r 2.009 -m 1.18
+Version -r 2.011 -m 1.19
 
 # defaults
 
@@ -81,7 +81,7 @@ StartSpinner () { # [<info_message>]
             for _Spinner_i in '|' '/' '-' '\'
             do
               printf " ${DSpinner} %s${D}${DCEL}\b\b\b" ${_Spinner_i} >&4 # duplicate stderr
-              sleep 0.1
+              sleep 0.1 2> /dev/null || sleep 1
             done
           done
         ) &
@@ -288,7 +288,7 @@ Sleep () { # [-i "<message>"] [-u <interval>] [<sleep>]
     while ((0 < (_Spinner_c-=${_Spinner_u})))
     do
       printf "${DJBL}${DInfo}${_Spinner_i}${D}${DCEL}" "${_Spinner_c}" >&4 # duplicate stderr
-      sleep ${_Spinner_u}
+      sleep ${_Spinner_u} 2> /dev/null || sleep $((${_Spinner_u%.*} + 1))
     done
     printf "${DJBL}${DCEL}" >&4 # duplicate stderr
   else

--- a/lib/sh/libuiTest.sh
+++ b/lib/sh/libuiTest.sh
@@ -150,6 +150,7 @@ LibuiTest () {
   local _Test_rv=0
   local _Test_success=true
   local _Test_testdir
+  local LIBUIEXE; ${ZSH} && LIBUIEXE="${commands[libui]}" || LIBUIEXE="$(command -v libui)"
 
   # get options
   ${_M} && _Trace 'Check for LibuiTest options. (%s)' "${*}"
@@ -275,7 +276,6 @@ LibuiTest () {
         ${_M} && _Trace 'Test command: %s' "${_Test_shell} ${CMDPATH} ${_Test_opt}${_Test_test}${_Test_param}"
         ${_Test_debug} && Tell 'Test command: %s' "${_Test_shell} ${CMDPATH} ${_Test_opt}${_Test_test}${_Test_param}"
         eval "Action -W -s ${_Test_warn} \"${_Test_env}${_Test_shell} ${CMDPATH} ${_Test_opt}${_Test_test}${_Test_param}\" ${_Test_log}"
-
 
         ${_M} && _Trace 'Check return value. (%s)' "${_Test_result}"
         case "${_Test_result}" in

--- a/lib/test/libui/test_ARCH
+++ b/lib/test/libui/test_ARCH
@@ -1,0 +1,15 @@
+#!/usr/bin/env libui
+#####
+#
+# test_ARCH
+#
+#####
+
+test_ARCH () {
+  local tarch="$(uname -m)"
+  LibuiPerformTest 'Tell -- "${ARCH}"'
+  LibuiValidateTest -r ${?} 0 "${tarch}"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_AddOption-S_Bad_Select_Var
+++ b/lib/test/libui/test_AddOption-S_Bad_Select_Var
@@ -6,7 +6,7 @@
 #####
 
 test_AddOption-S_Bad_Select_Var () {
-  LibuiPerformTest 'TERMINAL=true libui -x oS -Z a'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x oS -Z a'
   LibuiValidateTest -r ${?} 2 '.*ERROR: The value provided for -Z \(Test S\) is not an available option value\. \(a\).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddOption-s
+++ b/lib/test/libui/test_AddOption-s
@@ -6,7 +6,7 @@
 #####
 
 test_AddOption-s () {
-  LibuiPerformTest 'TERMINAL=true libui -x oA -h'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x oA -h'
   LibuiValidateTest -r ${?} 2 '.*-Z *Test A *- Test option A\. \(optA: \).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddOption-s-a
+++ b/lib/test/libui/test_AddOption-s-a
@@ -6,7 +6,7 @@
 #####
 
 test_AddOption-s-a () {
-  LibuiPerformTest 'TERMINAL=true libui -x oa -h'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x oa -h'
   LibuiValidateTest -r ${?} 2 '.*-Z *Test a *- Test option a\. \(opta: a\).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddOption-s_Bad_Select_Val
+++ b/lib/test/libui/test_AddOption-s_Bad_Select_Val
@@ -6,7 +6,7 @@
 #####
 
 test_AddOption-s_Bad_Select_Val () {
-  LibuiPerformTest 'TERMINAL=true libui -x os -Z x'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x os -Z x'
   LibuiValidateTest -r ${?} 2 '.*ERROR: The value provided for -Z \(Test s\) is not an available option value\. \(x\).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddParameter-S_Bad_Select_Var
+++ b/lib/test/libui/test_AddParameter-S_Bad_Select_Var
@@ -6,7 +6,7 @@
 #####
 
 test_AddParameter-S_Bad_Select_Var () {
-  LibuiPerformTest 'TERMINAL=true libui -x pS a'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x pS a'
   LibuiValidateTest -r ${?} 2 '.*ERROR: The value provided for testparam \(Test Param\) is not an available parameter value\. \(a\).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddParameter-s
+++ b/lib/test/libui/test_AddParameter-s
@@ -6,7 +6,7 @@
 #####
 
 test_AddParameter-s () {
-  LibuiPerformTest 'TERMINAL=true libui -x pA -h'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x pA -h'
   LibuiValidateTest -r ${?} 2 '.*<testparam> *- Test Param: Test parameter A\. \(testparam: \).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddParameter-s-a
+++ b/lib/test/libui/test_AddParameter-s-a
@@ -6,7 +6,7 @@
 #####
 
 test_AddParameter-s-a () {
-  LibuiPerformTest 'TERMINAL=true libui -x pa -h'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x pa -h'
   LibuiValidateTest -r ${?} 2 '.*<testparam> *- Test Param: Test parameter a\. \(testparam: a\).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddParameter-s_Bad_Select_Val
+++ b/lib/test/libui/test_AddParameter-s_Bad_Select_Val
@@ -6,7 +6,7 @@
 #####
 
 test_AddParameter-s_Bad_Select_Val () {
-  LibuiPerformTest 'TERMINAL=true libui -x ps x'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -x ps x'
   LibuiValidateTest -r ${?} 2 '.*ERROR: The value provided for testparam \(Test Param\) is not an available parameter value\. \(x\).*'
   return ${?}
 }

--- a/lib/test/libui/test_AddParameter_Missing
+++ b/lib/test/libui/test_AddParameter_Missing
@@ -6,7 +6,7 @@
 #####
 
 test_AddParameter_Missing () {
-  LibuiPerformTest 'TERMINAL=true libui -p'
+  LibuiPerformTest 'TERMINAL=true ${SHENV} ${LIBUIEXE} -p'
   LibuiValidateTest -r ${?} 2 '.*ERROR: Missing parameter\. \(.*\).*'
   return ${?}
 }

--- a/lib/test/libui/test_BSDPATH
+++ b/lib/test/libui/test_BSDPATH
@@ -1,0 +1,15 @@
+#!/usr/bin/env libui
+#####
+#
+# test_BSDPATH
+#
+#####
+
+test_BSDPATH () {
+  local tos="$(uname -s)"
+  [[ 'SunOS' == "${tos}" ]] && ${BSDPATH}grep -q 'Solaris' /etc/release 2> /dev/null && tbd='/usr/xpg4/bin/'
+  LibuiPerformTest 'Tell -- "B${BSDPATH}P"'
+  LibuiValidateTest -r ${?} 0 "B${tbd}P"
+}
+
+return 0

--- a/lib/test/libui/test_ConvertDate
+++ b/lib/test/libui/test_ConvertDate
@@ -6,12 +6,17 @@
 #####
 
 test_ConvertDate () {
-  LoadMod Convert
-  local short="$(date)"
-  local td="$(date '+%Y-%m-%d')"
-  ConvertDate short
-  LibuiPerformTest 'Tell "Date: %s" "${short}"'
-  LibuiValidateTest ${?} 0 "Date: ${td}"
+  if date -d &> /dev/null || date -j &> /dev/null || perl -e 'use Date::Parse;'
+  then
+    LoadMod Convert
+    local short="$(date)"
+    local td="$(date '+%Y-%m-%d')"
+    ConvertDate short
+    LibuiPerformTest 'Tell "Date: %s" "${short}"'
+    LibuiValidateTest ${?} 0 "Date: ${td}"
+  else
+    Tell -W -r 33 'Date conversions are not supported in %s. (%s)' "${OS}" "${OS_VERSION}"«
+  fi
   return ${?}
 }
 

--- a/lib/test/libui/test_ConvertDate_Date
+++ b/lib/test/libui/test_ConvertDate_Date
@@ -6,12 +6,17 @@
 #####
 
 test_ConvertDate_Date () {
-  LoadMod Convert
-  local short
-  local td="$(date '+%Y-%m-%d')"
-  ConvertDate short "$(date)"
-  LibuiPerformTest 'Tell "Date: %s" "${short}"'
-  LibuiValidateTest ${?} 0 "Date: ${td}"
+  if date -d &> /dev/null || date -j &> /dev/null || perl -e 'use Date::Parse;'
+  then
+    LoadMod Convert
+    local short
+    local td="$(date '+%Y-%m-%d')"
+    ConvertDate short "$(date)"
+    LibuiPerformTest 'Tell "Date: %s" "${short}"'
+    LibuiValidateTest ${?} 0 "Date: ${td}"
+  else
+    Tell -W -r 33 'Date conversions are not supported in %s. (%s)' "${OS}" "${OS_VERSION}"«
+  fi
   return ${?}
 }
 

--- a/lib/test/libui/test_GROUP
+++ b/lib/test/libui/test_GROUP
@@ -6,7 +6,7 @@
 #####
 
 test_GROUP () {
-  local grp="$(id -gn)"
+  local grp="$(${BSDPATH}id -gn)"
   LibuiPerformTest 'Tell -- "${GROUP}"'
   LibuiValidateTest ${?} 0 "${grp}"
   return ${?}

--- a/lib/test/libui/test_GetFileList-c_Hidden_Show
+++ b/lib/test/libui/test_GetFileList-c_Hidden_Show
@@ -1,0 +1,18 @@
+#!/usr/bin/env libui
+#####
+#
+# test_GetFileList-c_Hidden_Show
+#
+#####
+
+test_GetFileList-c_Hidden_Show () {
+  Action -W "mkdir -p ${TESTDIR}/hidden"
+  Action -W "touch ${TESTDIR}/hidden/.paths"
+  Action -W "mkdir -p ${TESTDIR}/hidden/.user"
+  Action -W "mkdir -p ${TESTDIR}/hidden/tmp"
+  LibuiPerformTest "GetFileList -c '${TESTDIR}/hidden' testhidden .env .paths .user .wsenv test tmp nope; Tell -- '%s' \"\${testhidden[*]}\""
+  LibuiValidateTest ${?} 0 ".paths .user tmp"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_Help
+++ b/lib/test/libui/test_Help
@@ -6,7 +6,7 @@
 #####
 
 test_Help () {
-  LibuiPerformTest 'TERMINAL=true TERM= libui -XC -XF -XH -XO -XN -XQ -XY '
+  LibuiPerformTest 'TERMINAL=true TERM= ${SHENV} ${LIBUIEXE} -XC -XF -XH -XO -XN -XQ -XY '
   LibuiValidateTest -i ${?} 2 "${helptext}"
   return ${?}
 }
@@ -67,6 +67,8 @@ regression testing, capabilities demonstration, and usage statistics reports.
 
 Hints: Use the \"-n\" (New Script) option to generate a new liubi script.
        Use the \"-d\" (Demo) option to see the display formats available.
+
+Shell environment: ${SHENV}
 
 Current test mode options:
     AddOption F/T test. (b: false)

--- a/lib/test/libui/test_Hookdir
+++ b/lib/test/libui/test_Hookdir
@@ -9,7 +9,7 @@ test_Hookdir () {
   local ldir; GetTmp -s ldir
   Write -c -f "${ldir}/libui-init" 'printf "Test hookdir init.\\n"'
   Write -c -f "${ldir}/libui-exit" 'printf "Test hookdir exit.\\n"'
-  LibuiPerformTest "LIBUI_HOOKDIR=\"${ldir}\" libui -x w"
+  LibuiPerformTest "LIBUI_HOOKDIR=\"${ldir}\" ${SHENV} ${LIBUIEXE} -x w"
   LibuiValidateTest ${?} 0 "Test hookdir init.${N}Hello World.${N}Test hookdir exit."
   return ${?}
 }

--- a/lib/test/libui/test_Ledger_File
+++ b/lib/test/libui/test_Ledger_File
@@ -7,7 +7,7 @@
 
 test_Ledger_File () {
   local lfile; GetTmp -f lfile
-  (LIBUI_LEDGER=true LIBUI_LEDGERFILE="${lfile}" libui -x w)
+  (LIBUI_LEDGER=true LIBUI_LEDGERFILE="${lfile}" ${SHENV} ${LIBUIEXE} -x w)
   LibuiPerformTest "wc -l '${lfile}'"
   LibuiValidateTest -r ${?} 0 " *1 *${lfile}"
   return ${?}

--- a/lib/test/libui/test_MkDir
+++ b/lib/test/libui/test_MkDir
@@ -6,10 +6,9 @@
 #####
 
 test_MkDir () {
-  groups=( $(groups) )
-  Action -W "MkDir -g ${groups[((AO + 1))]} -m '000' -s ${TESTDIR}/dir1/dir2"
+  Action -W "MkDir ${TESTDIR}/dir1/dir2"
   LibuiPerformTest "ls -l ${TESTDIR}/dir1"
-  LibuiValidateTest -r ${?} 0 "drwxrwsrwx.* ${groups[((AO + 1))]} .* dir2"
+  LibuiValidateTest -r ${?} 0 "d.* dir2"
   return ${?}
 }
 

--- a/lib/test/libui/test_MkDir_All
+++ b/lib/test/libui/test_MkDir_All
@@ -1,0 +1,16 @@
+#!/usr/bin/env libui
+#####
+#
+# test_MkDir_All
+#
+#####
+
+test_MkDir_All () {
+  groups=( $(groups) )
+  Action -W "MkDir -g ${groups[((AO + 1))]} -m '000' -s ${TESTDIR}/dir_all/dir2"
+  LibuiPerformTest "ls -l ${TESTDIR}/dir_all"
+  LibuiValidateTest -r ${?} 0 "drwxrwsrwx.* ${groups[((AO + 1))]} .* dir2"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_MkDir_Group
+++ b/lib/test/libui/test_MkDir_Group
@@ -1,0 +1,16 @@
+#!/usr/bin/env libui
+#####
+#
+# test_MkDir_Group
+#
+#####
+
+test_MkDir_Group () {
+  groups=( $(groups) )
+  Action -W "MkDir -g ${groups[((AO + 1))]} ${TESTDIR}/dir_group/dir2"
+  LibuiPerformTest "ls -l ${TESTDIR}/dir_group"
+  LibuiValidateTest -r ${?} 0 "d.* ${groups[((AO + 1))]} .* dir2"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_MkDir_Mask
+++ b/lib/test/libui/test_MkDir_Mask
@@ -1,0 +1,15 @@
+#!/usr/bin/env libui
+#####
+#
+# test_MkDir_Mask
+#
+#####
+
+test_MkDir_Mask () {
+  Action -W "MkDir -m '002' ${TESTDIR}/dir_mask/dir2"
+  LibuiPerformTest "ls -l ${TESTDIR}/dir_mask"
+  LibuiValidateTest -r ${?} 0 "drwxrwxr-x.* dir2"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_MkDir_SetGID
+++ b/lib/test/libui/test_MkDir_SetGID
@@ -1,0 +1,16 @@
+#!/usr/bin/env libui
+#####
+#
+# test_MkDir_SetGID
+#
+#####
+
+test_MkDir_SetGID () {
+  groups=( $(groups) )
+  Action -W "MkDir -g ${groups[((AO + 1))]} -s ${TESTDIR}/dir_setgid/dir2"
+  LibuiPerformTest "ls -l ${TESTDIR}/dir_setgid"
+  LibuiValidateTest -r ${?} 0 "d.....s.* ${groups[((AO + 1))]} .* dir2"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_Multiuser_Ledger_File
+++ b/lib/test/libui/test_Multiuser_Ledger_File
@@ -7,7 +7,7 @@
 
 test_Multiuser_Ledger_File () {
   local lfile; GetTmp -f lfile
-  (LIBUI_LEDGER=true LIBUI_LEDGERFILE="${lfile}" libui -x m -x w)
+  (LIBUI_LEDGER=true LIBUI_LEDGERFILE="${lfile}" ${SHENV} ${LIBUIEXE} -x m -x w)
   LibuiPerformTest "wc -l '${lfile}'"
   LibuiValidateTest -r ${?} 0 " *1 *${lfile}"
   return ${?}

--- a/lib/test/libui/test_Multiuser_Stats_File
+++ b/lib/test/libui/test_Multiuser_Stats_File
@@ -7,7 +7,7 @@
 
 test_Multiuser_Stats_File () {
   local lfile; GetTmp -f lfile
-  (LIBUI_STATS=true LIBUI_STATSFILE="${lfile}" libui -x m -x w)
+  (LIBUI_STATS=true LIBUI_STATSFILE="${lfile}" ${SHENV} ${LIBUIEXE} -x m -x w)
   LibuiPerformTest "grep '# libui stats on ' '${lfile}'"
   LibuiValidateTest -r ${?} 0 '# libui stats on .*'
   return ${?}

--- a/lib/test/libui/test_OS_DIST
+++ b/lib/test/libui/test_OS_DIST
@@ -1,0 +1,33 @@
+#!/usr/bin/env libui
+#####
+#
+# test_OS_DIST
+#
+#####
+
+test_OS_DIST () {
+  local tos="${tos:-$(uname -s)}"
+  local tosd
+  case "${tos}" in
+    Darwin)
+      tosd="$(sw_vers --ProductName)"
+      ;;
+
+    Linux)
+      eval $(eval $(grep -h '=' /etc/*release* 2> /dev/null) && printf 'tosd=%s\n' "${ID}")
+      ;;
+
+    SunOS|Solaris)
+      grep 'Solaris' /etc/release &> /dev/null && tosd='Solaris' || tosd='SunOS'
+      ;;
+
+    *)
+      ;;
+
+  esac
+  LibuiPerformTest 'Tell -- "${OS_DIST}"'
+  LibuiValidateTest -r ${?} 0 "${tosd}"
+  return ${?}
+}
+
+return 0

--- a/lib/test/libui/test_Stats_File
+++ b/lib/test/libui/test_Stats_File
@@ -7,7 +7,7 @@
 
 test_Stats_File () {
   local lfile; GetTmp -f lfile
-  (LIBUI_STATS=true LIBUI_STATSFILE="${lfile}" libui -x w)
+  (LIBUI_STATS=true LIBUI_STATSFILE="${lfile}" ${SHENV} ${LIBUIEXE} -x w)
   LibuiPerformTest "grep '# libui stats on ' '${lfile}'"
   LibuiValidateTest -r ${?} 0 '# libui stats on .*'
   return ${?}

--- a/lib/test/libui/test_Trace_File
+++ b/lib/test/libui/test_Trace_File
@@ -7,7 +7,7 @@
 
 test_Trace_File () {
   local lfile; GetTmp -f lfile
-  (LIBUI_TRACE=true LIBUI_TRACEFILE="${lfile}" libui -x w)
+  (LIBUI_TRACE=true LIBUI_TRACEFILE="${lfile}" ${SHENV} ${LIBUIEXE} -x w)
   LibuiPerformTest "grep 'Executed \"/.*/libui -x w\" on ' '${lfile}'"
   LibuiValidateTest -r ${?} 0 "Executed \"${script} -x w\" on .*"
   return ${?}

--- a/lib/test/libui/test_UNIX
+++ b/lib/test/libui/test_UNIX
@@ -12,11 +12,11 @@ test_UNIX () {
       tunix='GNU'
       ;;
 
-    Solaris)
-      tunix='SYSV'
+    SunOS|Solaris)
+      ${BSDPATH}grep -q 'Solaris' /etc/release && tunix='SYSV' || tunix='BSD'
       ;;
 
-    *) # Darwin|FreeBSD|SunOS
+    *) # Darwin|FreeBSD
       tunix='BSD'
       ;;
 

--- a/share/doc/libui-dictionary.md
+++ b/share/doc/libui-dictionary.md
@@ -1103,36 +1103,68 @@ Yes [-e|-E]
 The libui library defines the following variables for use in scripts. Please
 note that, while most are all caps, they are not environment variables.
 
-* **${AA}** - Associative Array: Set to "true" if the shell supports associative arrays.
-* **${AO}** - (Pq as in A O, not A zero) Array Offset: Set to "1" (one) if the shell is Z shell (zsh) and "0" (zero) otherwise.
+* **${AA}** - Associative Array: Set to "true" if the shell supports associative
+  arrays.
 * **${ANSWER}** - The last answer provided by the user via an Ask command.
-* **${IWD}** - The path of the directory where the script was initially executed.
-* **${BV}** - Bash Version: Set to the major and minor version of the Bash shell (without the
-intervening period). Note: If the executing shell is the Z shell, BV will be set to "0" (zero).
-* **${CHFLAGS}** - Chain flags: This variable collects command line flags (options) that should be passed on to chained scripts. (Chained scripts are scripts executed by the main script.) To properly use ${CHFLAGS}, place it as if it were a command line option for the script to be executed (e.g.: script ${CHFLAGS}). By default, the -XC, -XF, -XN, -XQ, and -XY options are automatically captured. Additional flags can be added as needed using the -C (Chain) option flag with AddOption.
+* **${AO}** - (Pq as in A O, not A zero) Array Offset: Set to "1" (one) if the
+  shell is Z shell (zsh) and "0" (zero) otherwise.
+* **${ARCH}** - The system architecture (as reported by the system).
+* **${BSDPATH}** - The path to the BSD version of an application (for Solaris).
+* **${BV}** - Bash Version: Set to the major and minor version of the Bash shell
+  (without the intervening period). Note: If the executing shell is the Z shell,
+  BV will be set to "0" (zero).
+* **${CHFLAGS}** - Chain flags: This variable collects command line flags
+  (options) that should be passed on to chained scripts. (Chained scripts are
+  scripts executed by the main script.) To properly use ${CHFLAGS}, place it as
+  if it were a command line option for the script to be executed (e.g.: script
+  ${CHFLAGS}). By default, the -XC, -XF, -XN, -XQ, and -XY options are
+  automatically captured. Additional flags can be added as needed using the -C
+  (Chain) option flag with AddOption.
 * **${CMD}** - The command name, i.e., the filename of the main script.
 * **${CMDARGS}** - An array containing the arguments provided on the command line.
-* **${CMDLINE}** - The full command line string used to call the current script. This is the same as: ${CMD} "${CMDARGS[@]}"
+* **${CMDLINE}** - The full command line string used to call the current script.
+  This is the same as: ${CMD} "${CMDARGS[@]}"
 * **${CMDPATH}** - The absolute path of the main script file.
 * **${DOMAIN}** - The domain of the current machine.
-* **${FMFLAGS}** - File management flags: For use by cp, mv, rm. Note: ${FMFLAGS} is set to "-i" by -C (Confirm) and to "-f" by-F (Force) options.
+* **${FMFLAGS}** - File management flags: For use by cp, mv, rm. Note:
+  ${FMFLAGS} is set to "-i" by -C (Confirm) and to "-f" by-F (Force) options.
 * **${GROUP}** - The primary group of the user.
 * **${HEIGHT}** - Terminal window height in rows.
-* **${HOST}** - The hostname of the current machine (hostname only, not fully qualified).
+* **${HOST}** - The hostname of the current machine (hostname only, not fully
+  qualified).
+* **${IWD}** - The path of the directory where the script was initially executed.
 * **${LIBUI}** - The absolute path of the included libui.sh source file.
-* **${MAXCOL}** - Maximum terminal window column. Equivalent to WIDTH - 1. Note: Terminal columns start at 0.
+* **${MAXCOL}** - Maximum terminal window column. Equivalent to WIDTH - 1. Note:
+  Terminal columns start at 0.
 * **${MAXINT}** - Maximum integer: Set to the shell's maximum integer value.
-* **${MAXROW}** - Maximum terminal window row. Equivalent to HEIGHT - 1. Note: Terminal rows start at 0.
-* **${N}** - The newline character. This is equivalent to $'\n' but, available for use in string assignments.
+* **${MAXROW}** - Maximum terminal window row. Equivalent to HEIGHT - 1. Note:
+  Terminal rows start at 0.
+* **${N}** - The newline character. This is equivalent to $'\n' but, available
+  for use in string assignments.
 * **${NROPT}** - The number of options provided on the command line.
 * **${NRPARAM}** - The number of parameters provided on the command line.
-* **${OS}** - The name of the operating system. Typical values are Darwin, Linux, SunOS, Solaris, etc.
-* **${SHENV}** - The path of the currently executing shell (limited to: zsh, bash, or sh).
-* **${TERMINAL}** - Set to "true" if standard out is to a terminal, "false" if standard out is not to a terminal. When standard out is to a terminal, the libui library generates color text and additional user cues including questions, etc. Note: The ${TERMINAL} variable  can be set to "true" or "false" before executing the script (or sourcing libui.sh) to force enabling / disabling these terminal effects. Note: The ${TERMINAL} variable is only set during initialization and should not be used to determine if output is actually to a terminal. Use the [[ -t 1 ]] construct to determine if STDOUT is actually to a terminal.
-* **${UICMD}** - An array containing the names of (available) libui commands (including libui mod provided commands).
+* **${OS}** - The name of the operating system. Typical values are Darwin,
+  Linux, SunOS, Solaris, etc.
+* **${OS_DIST}** - The operating system distribution. Typical values are
+  almalinux, debian, rhel, SunOS, Solaris, ubuntu, etc.
+* **${SHENV}** - The path of the currently executing shell (limited to: zsh,
+  bash, or sh).
+* **${TERMINAL}** - Set to "true" if standard out is to a terminal, "false" if
+  standard out is not to a terminal. When standard out is to a terminal, the
+  libui library generates color text and additional user cues including
+  questions, etc. Note: The ${TERMINAL} variable  can be set to "true" or
+  "false" before executing the script (or sourcing libui.sh) to force enabling /
+  disabling these terminal effects. Note: The ${TERMINAL} variable is only set
+  during initialization and should not be used to determine if output is
+  actually to a terminal. Use the [[ -t 1 ]] construct to determine if STDOUT is
+  actually to a terminal.
+* **${UICMD}** - An array containing the names of (available) libui commands
+  (including libui mod provided commands).
 * **${UIMOD}** - An array containing the filenames of loaded libui mods.
-* **${UIVERSION}** - An array containing the filenames and versions of the loaded scripts and libui mods in alternating "pairs": \<file\> \<version\> ...
-* **${UNIX}** - The type of the operating system. The possible values are BSD, SYSV, or GNU (e.g. Linux).
+* **${UIVERSION}** - An array containing the filenames and versions of the
+  loaded scripts and libui mods in alternating "pairs": \<file\> \<version\> ...
+* **${UNIX}** - The type of the operating system. The possible values are BSD,
+  SYSV, or GNU (i.e. Linux).
 * **${WIDTH}** - Terminal window width in colums.
 * **${ZSH}** - Z shell - Set to "true" if the shell is Z shell (zsh).
 

--- a/share/man/man3/libui.sh.3
+++ b/share/man/man3/libui.sh.3
@@ -2030,18 +2030,20 @@ library:
 .Bl -tag -offset 4n -width 12n
 .It Dv ${AA}
 Associative Array: Set to "true" if the shell supports associative arrays.
+.It Dv ${ANSWER}
+The last answer provided by the user via an Ask command.
 .It Dv ${AO} Pq as in A O, not A zero
 Array Offset: Set to "1" (one) if the shell is Z shell (zsh) and "0" (zero)
 otherwise.
-.It Dv ${ANSWER}
-The last answer provided by the user via an Ask command.
-.It Dv ${IWD}
-The path of the directory where the script was initially executed.
+.It Dv ${ARCH}
+The system architecture (as reported by the system).
 .It Dv ${BV}
 Bash Version: Set to the major and minor version of the Bash shell (without the
 intervening period).
 .Pp
 Note: If the executing shell is the Z shell, BV will be set to "0" (zero).
+.It Dv ${BSDPATH}
+The path to the BSD version of an application (for Solaris).
 .It Dv ${CHFLAGS}
 Chain flags: This variable collects command line flags (options) that should be
 passed on to chained scripts.
@@ -2086,6 +2088,8 @@ The primary group of the user.
 Terminal window height in rows.
 .It Dv ${HOST}
 The hostname of the current machine (hostname only, not fully qualified).
+.It Dv ${IWD}
+The path of the directory where the script was initially executed.
 .It Dv ${LIBUI}
 The absolute path of the included
 .Nm
@@ -2111,6 +2115,8 @@ The number of parameters provided on the command line.
 .It Dv ${OS}
 The name of the operating system.
 Typical values are Darwin, Linux, SunOS, Solaris, etc.
+.It Dv ${OS_DIST}
+The operating system distribution. Typical values are almalinux, debian, rhel, SunOS, Solaris, ubuntu, etc.
 .It Dv ${SHENV}
 The path of the currently executing shell (limited to: zsh, bash, or sh).
 .It Dv ${TERMINAL}
@@ -2147,7 +2153,7 @@ An array containing the filenames and versions of the loaded scripts and
 mods in alternating "pairs": <file> <version> ...
 .It Dv ${UNIX}
 The type of the operating system.
-The possible values are BSD, SYSV, or GNU (e.g. Linux).
+The possible values are BSD, SYSV, or GNU (i.e. Linux).
 .It Dv ${WIDTH}
 Terminal window width in colums.
 .It Dv ${ZSH}


### PR DESCRIPTION
### New Features / Enhancements

* Add new `${ARCH}` variable that provides the system architecture.
* Add new `${BSDPATH}` variable that provides the path for BSD command versions.
* Add new `${OS_DIST}` variable that provides the OS distribution.
* Ignore `.DS_Store` files when comparing directories with `libui -[uvV]`.
* Improve `mless` multi-line handling.
* Multiple tweaks for better support in bash on Solaris 10 (zsh not supported).
* Add "gtarp" package type in libui Package mod for gtar installation (Solaris).
* Add and update regression tests.
* Update documentation.

### Bug Fixes

* Fix libui File mod `GetFileList` bug on filenames with leading period in bash.
* Use ls -i instead of stat for inodes in libui File mod `PathMatches` (Solaris).
* Tweak libui Package mod package header use of head -n / tail -n (Solaris).
* Round fractional `sleep` values up one second if the fractional sleep fails.
* Add quotes in a few variable assignments to reduce security exposure.

### Incompatibilities

* The `${OS}` on Solaris is now "SunOS" (and `${OS_DIST}` is "Solaris").